### PR TITLE
Feat/own card view

### DIFF
--- a/lib/helper/contact_manager.dart
+++ b/lib/helper/contact_manager.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:connect2/services/contacts_service.dart';
+import 'package:flutter_contacts/flutter_contacts.dart';
 
 class ContactManager {
   final int contactId;
@@ -8,6 +9,10 @@ class ContactManager {
   Timer? _debounceTimer;
 
   ContactManager(this.contactId, this.contactData);
+
+  ContactManager.withId(this.contactId) {
+    contactData = {};
+  }
 
   // Method will be called on every change
   void updateContactField(String field, dynamic value) {
@@ -22,8 +27,29 @@ class ContactManager {
   Future<void> _saveContactToDatabase() async {
     print("Speichere Kontakt in der Datenbank: $contactData");
     // TODO Update database here
+    Contact updatedContact = Contact();
+    updatedContact.id = contactId.toString();
+    updatedContact.name.first = contactData["name"];
+    updatedContact.addresses.first = Address(contactData["residence"]);
+    updatedContact.organizations.first = contactData["employer"];
+
+    // Save updated Contact to phone contacts
+    saveModifiedContact(updatedContact);
     // await database.update(contactId, contactData);
   }
+
+  Future<void> loadContactFromDatabase() async {
+  // Simuliere das Laden von Daten aus der Datenbank
+  await Future.delayed(const Duration(seconds: 1)); // Simulates Loading Time for now
+  Contact contact = await getContact(contactId.toString());
+  contactData = {
+    "name": contact.name.first,
+    "birthDate": DateTime(1990, 1, 1),
+    "residence": "Berlin",
+    "employer": "TechCorp",
+    "skills": ["C", "Design"],
+  };
+}
 
   // Keep if we also want to save manually via button
   Future<void> saveManually() async {

--- a/lib/helper/contact_manager.dart
+++ b/lib/helper/contact_manager.dart
@@ -25,7 +25,6 @@ class ContactManager {
   }
 
   Future<void> _saveContactToDatabase() async {
-    print("Speichere Kontakt in der Datenbank: $contactData");
     // TODO Update database here
     Contact updatedContact = Contact();
     updatedContact.id = contactId.toString();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,6 @@
 import 'package:connect2/screens/graph_screen.dart';
 import 'package:flutter/material.dart';
-import 'package:connect2/screens/person_card_view.dart';
+import 'package:connect2/screens/first_own_card.dart';
 import 'package:connect2/screens/home_view.dart';
 
 void main() {
@@ -35,9 +35,9 @@ class _MyHomePageState extends State<MyHomePage> {
   int _selectedIndex = 0;
 
   static final List<Widget> _widgetOptions = <Widget>[
-    const HomeContent(),
-    const PersonCardView(), 
+    const HomeContent(), 
     const GraphScreen(),
+    const OwnContactView()
   ];
 
   void _onItemTapped(int index) {
@@ -56,16 +56,16 @@ class _MyHomePageState extends State<MyHomePage> {
       body: Center(
         child: _widgetOptions.elementAt(_selectedIndex),  // Wählt die View basierend auf dem Index aus
       ),
-      floatingActionButton: FloatingActionButton.large(
-        onPressed: () {
-          Navigator.push(
-            context,
-            MaterialPageRoute(builder: (context) => const PersonCardView()),
-          );
-        },
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ),
+      // floatingActionButton: FloatingActionButton.large(
+      //   onPressed: () {
+      //     Navigator.push(
+      //       context,
+      //       MaterialPageRoute(builder: (context) => const PersonCardView()),
+      //     );
+      //   },
+      //   tooltip: 'Increment',
+      //   child: const Icon(Icons.add),
+      // ),
       bottomNavigationBar: NavigationBar(
         selectedIndex: _selectedIndex,  
         onDestinationSelected: _onItemTapped,  
@@ -77,12 +77,12 @@ class _MyHomePageState extends State<MyHomePage> {
             label: 'Home',
           ),
           NavigationDestination(
-            icon: Icon(Icons.person),
-            label: 'Person View',
+            icon: Icon(Icons.network_cell),
+            label: 'Graph',
           ),
           NavigationDestination(
-            icon: Icon(Icons.notifications),
-            label: 'Notification',
+            icon: Icon(Icons.person),
+            label: 'Karte',
           ),
         ],
       ),

--- a/lib/screens/first_own_card.dart
+++ b/lib/screens/first_own_card.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_contacts/flutter_contacts.dart';
+import 'package:connect2/services/contacts_service.dart'; 
+import 'package:connect2/screens/person_card_view.dart';
+import 'package:connect2/screens/own_card.dart';
+
+class OwnContactView extends StatefulWidget {
+  const OwnContactView({super.key});
+
+  @override
+  _OwnContactViewState createState() => _OwnContactViewState();
+}
+
+class _OwnContactViewState extends State<OwnContactView> {
+  Contact? _ownContact;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadOwnContact();
+  }
+
+  Future<void> _loadOwnContact() async {
+    print("\n");
+    print("Reload the view");
+    final contact = await getOwnContact();
+    print("I can find the contact: $contact");
+    setState(() {
+      _ownContact = contact;
+    });
+  }
+
+  void _selectExistingContact() async {
+    final contacts = await getContacts(); // Liste aller Kontakte abrufen
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text('Wähle einen Kontakt'),
+          content: SizedBox(
+            width: double.maxFinite,
+            child: ListView.builder(
+              itemCount: contacts.length,
+              itemBuilder: (context, index) {
+                final contact = contacts[index];
+                return ListTile(
+                  title: Text(contact.displayName ?? 'Unbekannt'),
+                  onTap: () async {
+                    await saveOwnContactId(contact.id); // Speichere die ID des ausgewählten Kontakts
+                    Navigator.pop(context);
+                    _loadOwnContact(); // Aktualisiere die View
+                  },
+                );
+              },
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  void _showNameInputDialog(BuildContext context) {
+    final TextEditingController nameController = TextEditingController();
+
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text("Neuer Kontakt"),
+          content: TextField(
+            controller: nameController,
+            decoration: const InputDecoration(
+              hintText: "Namen eingeben",
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.pop(context);
+              },
+              child: const Text("Abbrechen"),
+            ),
+            TextButton(
+              onPressed: () async {
+                final String name = nameController.text.trim();
+                if (name.isNotEmpty) {
+                  Contact contact = Contact(name: Name(first: name));
+
+                  int contactId = await saveNewContact(contact);
+                  saveOwnContactId(contactId.toString());
+                  Navigator.push(
+                    context, 
+                    MaterialPageRoute(builder: (context) => PersonCardView(contactId: contactId))); 
+                }
+              },
+              child: const Text("Speichern"),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  void _createNewContact() async {
+    _showNameInputDialog(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // if own contact exists just show the view for ownContact
+    if (_ownContact != null) {
+      int contactId = int.parse(_ownContact!.id);
+      return OwnCardView(contactId: contactId);
+    }
+
+    // If own contact doenst exist, show buttons to select what to do
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Eigener Kontakt'),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            ElevatedButton(
+              onPressed: _selectExistingContact,
+              child: const Text('Bestehenden Kontakt auswählen'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: _createNewContact,
+              child: const Text('Neuen Kontakt erstellen'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/first_own_card.dart
+++ b/lib/screens/first_own_card.dart
@@ -21,22 +21,19 @@ class _OwnContactViewState extends State<OwnContactView> {
   }
 
   Future<void> _loadOwnContact() async {
-    print("\n");
-    print("Reload the view");
     final contact = await getOwnContact();
-    print("I can find the contact: $contact");
     setState(() {
       _ownContact = contact;
     });
   }
 
   void _selectExistingContact() async {
-    final contacts = await getContacts(); // Liste aller Kontakte abrufen
+    final contacts = await getContacts();
     showDialog(
       context: context,
       builder: (context) {
         return AlertDialog(
-          title: Text('Wähle einen Kontakt'),
+          title: const Text('Wähle einen Kontakt'),
           content: SizedBox(
             width: double.maxFinite,
             child: ListView.builder(
@@ -44,11 +41,11 @@ class _OwnContactViewState extends State<OwnContactView> {
               itemBuilder: (context, index) {
                 final contact = contacts[index];
                 return ListTile(
-                  title: Text(contact.displayName ?? 'Unbekannt'),
+                  title: Text(contact.displayName),
                   onTap: () async {
-                    await saveOwnContactId(contact.id); // Speichere die ID des ausgewählten Kontakts
+                    await saveOwnContactId(contact.id);
                     Navigator.pop(context);
-                    _loadOwnContact(); // Aktualisiere die View
+                    _loadOwnContact();
                   },
                 );
               },
@@ -116,7 +113,7 @@ class _OwnContactViewState extends State<OwnContactView> {
     // If own contact doenst exist, show buttons to select what to do
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Eigener Kontakt'),
+        title: const Text('Eigenen Kontakt auswählen'),
       ),
       body: Center(
         child: Column(

--- a/lib/screens/home_view.dart
+++ b/lib/screens/home_view.dart
@@ -3,6 +3,7 @@ import 'package:connect2/screens/person_card_view.dart';
 import 'package:connect2/services/contacts_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_contacts/flutter_contacts.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 // HomeContent Widget: Die scrollbare Liste
 class HomeContent extends StatefulWidget {
@@ -35,6 +36,84 @@ class HomeContentState extends State<HomeContent> {
     loadContacts();
   }
 
+  void _showMenu(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      builder: (BuildContext context) {
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.qr_code),
+              title: const Text("QR-Code importieren"),
+              onTap: () {
+                Navigator.pop(context);
+                // Implementiere hier die Funktionalität für den QR-Code
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.create),
+              title: const Text("Manuell erstellen"),
+              onTap: () {
+                Navigator.pop(context); 
+                _showNameInputDialog(context); 
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.delete),
+              title: const Text("Daten zurücksetzen"),
+              onTap: () async {
+                final prefs = await SharedPreferences.getInstance();
+                await prefs.clear();
+              },
+            )
+          ],
+        );
+      },
+    );
+  }
+
+  void _showNameInputDialog(BuildContext context) {
+    final TextEditingController nameController = TextEditingController();
+
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text("Neuer Kontakt"),
+          content: TextField(
+            controller: nameController,
+            decoration: const InputDecoration(
+              hintText: "Namen eingeben",
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.pop(context);
+              },
+              child: const Text("Abbrechen"),
+            ),
+            TextButton(
+              onPressed: () async {
+                final String name = nameController.text.trim();
+                if (name.isNotEmpty) {
+                  Contact contact = Contact(name: Name(first: name));
+
+                  int contactId = await saveNewContact(contact);;
+                  Navigator.push(
+                    context, 
+                    MaterialPageRoute(builder: (context) => PersonCardView(contactId: contactId))); 
+                }
+              },
+              child: const Text("Speichern"),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     // TODO prettify the view
@@ -63,21 +142,25 @@ class HomeContentState extends State<HomeContent> {
 
     // TODO prettify the message
     if (contacts.isEmpty) {
-      return const Scaffold(
+      return Scaffold(
+        floatingActionButton: FloatingActionButton(
+          onPressed: () {
+            _showMenu(context);
+          },
+          tooltip: "Menü anzeigen",
+          child: const Icon(Icons.add),
+        ),
         body:
-            Center(child: Text('No contacts have been found.')), // TODO add i18
+            Center(child: Text('Es wurden keine Kontakte gefunden.')), // TODO add i18
       );
     }
 
     return Scaffold(
       floatingActionButton: FloatingActionButton(
         onPressed: () {
-          Navigator.push(
-            context,
-            MaterialPageRoute(builder: (context) => const PersonCardView()),
-          );
+          _showMenu(context);
         },
-        tooltip: 'Increment',
+        tooltip: 'Menü anzeigen',
         child: const Icon(Icons.add),
       ),
       body: ListView.builder(

--- a/lib/screens/own_card.dart
+++ b/lib/screens/own_card.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:permission_handler/permission_handler.dart';
-import 'package:connect2/main.dart';
 
 class OwnCardView extends StatefulWidget {
   final int contactId;
@@ -18,6 +17,8 @@ class _OwnCardViewState extends State<OwnCardView> {
   late int contactId;
   late ContactManager _contactManager;
   bool _isLoading = true;
+  late TextEditingController _residenceController;
+  late TextEditingController _employerController;
   // General Information
   String _name = "";
   DateTime? _birthDate;
@@ -39,6 +40,13 @@ class _OwnCardViewState extends State<OwnCardView> {
     
   }
 
+  @override
+  void dispose() {
+    _residenceController.dispose();
+    _employerController.dispose();
+    super.dispose();
+  }
+
   Future<void> _initializeData() async {
     await _contactManager.loadContactFromDatabase();
     setState(() {
@@ -46,6 +54,10 @@ class _OwnCardViewState extends State<OwnCardView> {
       _birthDate = _contactManager.contactData["birthDate"];
       _residence = _contactManager.contactData["residence"] ?? "";
       _employer = _contactManager.contactData["employer"] ?? "";
+      
+      // Set controller
+      _residenceController = TextEditingController(text: _residence);
+      _employerController = TextEditingController(text: _employer);
 
       // Skills
       _skills.clear();
@@ -468,6 +480,17 @@ class _OwnCardViewState extends State<OwnCardView> {
         ],
       );
     }
+
+    TextEditingController controller;
+    if (label == 'Wohnort') {
+      controller = _residenceController;
+    }
+    else if (label == 'Arbeitgeber / Uni'){
+      controller = _employerController;
+    }
+    else {
+      controller = TextEditingController(text: value); // Fallback
+    }
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -480,7 +503,7 @@ class _OwnCardViewState extends State<OwnCardView> {
         ),
         const SizedBox(height: 4),
         TextField(
-          controller: TextEditingController(text: value),
+          controller: controller,
           onChanged: (newValue) {
             setState(() {
               if (label == 'Wohnort') {

--- a/lib/screens/own_card.dart
+++ b/lib/screens/own_card.dart
@@ -4,18 +4,17 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:permission_handler/permission_handler.dart';
-import 'package:connect2/models/note.dart';
 import 'package:connect2/main.dart';
 
-class PersonCardView extends StatefulWidget {
+class OwnCardView extends StatefulWidget {
   final int contactId;
-  const PersonCardView({Key? key, required this.contactId}) : super(key: key);
+  const OwnCardView({Key? key, required this.contactId}) : super(key: key);
   @override
   // ignore: library_private_types_in_public_api
-  _PersonCardViewState createState() => _PersonCardViewState();
+  _OwnCardViewState createState() => _OwnCardViewState();
 }
 
-class _PersonCardViewState extends State<PersonCardView> {
+class _OwnCardViewState extends State<OwnCardView> {
   late int contactId;
   late ContactManager _contactManager;
   bool _isLoading = true;
@@ -24,8 +23,6 @@ class _PersonCardViewState extends State<PersonCardView> {
   DateTime? _birthDate;
   String _residence = "";
   String _employer = "";
-  // Notes
-  final List<Note> _noteList = [];
 
   // Skills
   final List<String> _skills = [];
@@ -49,17 +46,6 @@ class _PersonCardViewState extends State<PersonCardView> {
       _birthDate = _contactManager.contactData["birthDate"];
       _residence = _contactManager.contactData["residence"] ?? "";
       _employer = _contactManager.contactData["employer"] ?? "";
-
-      // Notes
-      _noteList.clear();
-      final List<Map<String, dynamic>> notesFromDb = _contactManager.contactData["notes"] ?? [];
-      for (var noteData in notesFromDb) {
-        _noteList.add(Note(
-          date: noteData["date"] ?? "",
-          text: noteData["text"] ?? "",
-        ));
-      }
-
 
       // Skills
       _skills.clear();
@@ -85,31 +71,7 @@ class _PersonCardViewState extends State<PersonCardView> {
       });
     }
   }
-
-  void updatePersonalInfo(String name, DateTime birthDate, String residence, String employer) {
-    setState(() {
-      _name = name;
-      _birthDate = birthDate;
-      _residence = residence;
-      _employer = employer;
-    });
-  }
-
-  void _addNote(String newText) {
-    setState(() {
-      String formattedDate = DateFormat('dd.MM.yyyy').format(DateTime.now());
-      _noteList.add(Note(date: formattedDate, text: newText));
-      _contactManager.updateContactField('notes', _noteList.map((note) => note.toJson()).toList());
-    });
-  }
-
-  void _deleteNote(int index) {
-    setState(() {
-      _noteList.removeAt(index);
-      _contactManager.updateContactField('notes', _noteList.map((note) => note.toJson()).toList());
-    });
-  }
-
+  
   void _addSkill(String newSkill){
     setState(() {
       _skills.add(newSkill);
@@ -126,7 +88,7 @@ class _PersonCardViewState extends State<PersonCardView> {
 
   /// This method shows a pop up to create a new entry to a list. This is used for the skills and the notes.
   /// The input field is not allowed to be empty.
-  Future<void> _showAddItemDialog(Function(String) onAdd ) async {
+  Future<void> _showAddSkillDialog() async {
     String itemText = '';
     bool isError = false;
 
@@ -136,7 +98,7 @@ class _PersonCardViewState extends State<PersonCardView> {
         return StatefulBuilder(
           builder: (context, setState) {
             return AlertDialog(
-              title: const Text('Neues Item hinzufügen'),
+              title: const Text('Neuen Skill hinzufügen'),
               content: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
@@ -171,7 +133,7 @@ class _PersonCardViewState extends State<PersonCardView> {
                         isError = true;
                       });
                     } else {
-                      onAdd(itemText);
+                      _addSkill(itemText);
                       Navigator.of(context).pop();
                     }
                   },
@@ -285,21 +247,6 @@ class _PersonCardViewState extends State<PersonCardView> {
     }
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Kontakt'),
-        backgroundColor: colorScheme.primary,
-        foregroundColor: const Color.fromRGBO(255, 255, 255, 1),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () {
-            Navigator.pushAndRemoveUntil(
-              context,
-              MaterialPageRoute(builder: (context) => const MyApp()),
-              (Route<dynamic> route) => false,
-            );
-          },
-        ),
-      ),
       body: SingleChildScrollView(
         child: Padding(
           padding: const EdgeInsets.all(16.0),
@@ -407,75 +354,10 @@ class _PersonCardViewState extends State<PersonCardView> {
                   const SizedBox(height: 16),
                 ],
                 floatingActionButton: FloatingActionButton.small(
-                  onPressed: () => _showAddItemDialog(_addSkill),
+                  onPressed: () => _showAddSkillDialog(),
                   backgroundColor: colorScheme.primaryContainer,
                   child: Icon(Icons.add, color: colorScheme.onPrimaryContainer),
                 ),
-              ),          
-
-              // Notizen
-              _buildInfoCard(
-                colorScheme,
-                'Notizen',
-                [
-                  ListView.builder(
-                    shrinkWrap: true,
-                    physics: const NeverScrollableScrollPhysics(),
-                    itemCount: _noteList.length,
-                    itemBuilder: (context, index) {
-                      final notiz = _noteList[index];
-                      return Dismissible(
-                        key: UniqueKey(),
-                        direction: DismissDirection.startToEnd,
-                        onDismissed: (direction) {
-                          _deleteNote(index);
-                        },
-                        background: Container(
-                          color: Colors.red,
-                          padding: const EdgeInsets.only(left: 16),
-                          alignment: Alignment.centerLeft,
-                          child: const Icon(Icons.delete, color: Colors.white),
-                        ),
-                        child: Padding(
-                          padding: const EdgeInsets.symmetric(vertical: 8.0),
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(
-                                notiz.date,
-                                style: TextStyle(
-                                  fontWeight: FontWeight.bold,
-                                  color: colorScheme.onSurface,
-                                ),
-                              ),
-                              const SizedBox(height: 4),
-                              TextFormField(
-                                initialValue: notiz.text,
-                                readOnly: true,
-                                maxLines: null,
-                                style: TextStyle(color: colorScheme.onSurfaceVariant),
-                                decoration: InputDecoration(
-                                  filled: true,
-                                  fillColor: colorScheme.surfaceContainerHighest,
-                                  border: OutlineInputBorder(
-                                    borderRadius: BorderRadius.circular(8),
-                                  ),
-                                ),
-                              ),
-                            ],
-                          ),
-                        ),
-                      );
-                    },
-                  ),
-                  const SizedBox(height: 16),
-                ],
-                floatingActionButton: 
-                  FloatingActionButton.small(
-                  onPressed: () => _showAddItemDialog(_addNote),
-                  backgroundColor: colorScheme.primaryContainer,
-                  child: Icon(Icons.add, color: colorScheme.onPrimaryContainer),
-                )
               ),
             ],
           ),

--- a/lib/screens/person_card_view.dart
+++ b/lib/screens/person_card_view.dart
@@ -19,7 +19,9 @@ class _PersonCardViewState extends State<PersonCardView> {
   late int contactId;
   late ContactManager _contactManager;
   bool _isLoading = true;
-  // General Information
+  late TextEditingController _residenceController;
+  late TextEditingController _employerController;
+
   String _name = "";
   DateTime? _birthDate;
   String _residence = "";
@@ -42,6 +44,13 @@ class _PersonCardViewState extends State<PersonCardView> {
     
   }
 
+  @override
+  void dispose() {
+    _residenceController.dispose();
+    _employerController.dispose();
+    super.dispose();
+  }
+
   Future<void> _initializeData() async {
     await _contactManager.loadContactFromDatabase();
     setState(() {
@@ -49,6 +58,10 @@ class _PersonCardViewState extends State<PersonCardView> {
       _birthDate = _contactManager.contactData["birthDate"];
       _residence = _contactManager.contactData["residence"] ?? "";
       _employer = _contactManager.contactData["employer"] ?? "";
+
+      // Controller
+      _residenceController = TextEditingController(text: _residence);
+      _employerController = TextEditingController(text: _employer);
 
       // Notes
       _noteList.clear();
@@ -84,15 +97,6 @@ class _PersonCardViewState extends State<PersonCardView> {
         _contactManager.updateContactField('birthDate', pickedDate.toIso8601String());
       });
     }
-  }
-
-  void updatePersonalInfo(String name, DateTime birthDate, String residence, String employer) {
-    setState(() {
-      _name = name;
-      _birthDate = birthDate;
-      _residence = residence;
-      _employer = employer;
-    });
   }
 
   void _addNote(String newText) {
@@ -586,6 +590,17 @@ class _PersonCardViewState extends State<PersonCardView> {
         ],
       );
     }
+
+    TextEditingController controller;
+    if (label == 'Wohnort') {
+      controller = _residenceController;
+    }
+    else if (label == 'Arbeitgeber / Uni'){
+      controller = _employerController;
+    }
+    else {
+      controller = TextEditingController(text: value); // Fallback
+    }
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -598,7 +613,7 @@ class _PersonCardViewState extends State<PersonCardView> {
         ),
         const SizedBox(height: 4),
         TextField(
-          controller: TextEditingController(text: value),
+          controller: controller,
           onChanged: (newValue) {
             setState(() {
               if (label == 'Wohnort') {

--- a/lib/services/contacts_service.dart
+++ b/lib/services/contacts_service.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_contacts/flutter_contacts.dart';
 import 'package:connect2/exceptions/exceptions.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 
 /// Retrieves a list of all contacts from the device's contact list.
@@ -71,14 +72,46 @@ Future<void> saveModifiedContact(Contact contact) async {
 ///
 /// - Parameter contact: The `Contact` object to save as a new contact.
 /// - Throws: `PermissionDeniedException` if contact permissions are not granted.
-Future<void> saveNewContact(Contact contact) async {
+Future<int> saveNewContact(Contact contact) async {
   if (await FlutterContacts.requestPermission()) {
     try {
-      await FlutterContacts.insertContact(contact);
+      contact = await FlutterContacts.insertContact(contact);
+      // contact.displayName = name;
+      // await FlutterContacts.updateContact(contact);
     } catch (e) {
       throw Exception('Failed to save new contact: ${e.toString()}');
     }
   } else {
     throw PermissionDeniedException('Contact permissions were not granted.');
   }
+  return int.parse(contact.id);
+}
+
+// Saves the id of the users own contact.
+///
+/// This method takes an id and stores it in the shared preferences. This function will only be called once.
+///
+/// - Parameter contactId: String, the contactId of the users own contact.
+Future<void> saveOwnContactId(String contactId) async {
+  final prefs = await SharedPreferences.getInstance();
+  await prefs.setString('own_contact_id', contactId);
+}
+
+Future<String?> getOwnContactId() async {
+  final prefs = await SharedPreferences.getInstance();
+  return prefs.getString('own_contact_id');
+}
+
+
+Future<Contact?> getOwnContact() async {
+  final contactId = await getOwnContactId();
+  if (contactId != null) {
+    final contacts = await FlutterContacts.getContacts();
+    try {
+      return contacts.firstWhere((c) => c.id == contactId);
+    } catch (e) {
+      return null;
+    }
+  }
+  return null;
 }

--- a/lib/services/contacts_service.dart
+++ b/lib/services/contacts_service.dart
@@ -97,12 +97,13 @@ Future<void> saveOwnContactId(String contactId) async {
   await prefs.setString('own_contact_id', contactId);
 }
 
+/// Gets the Id of the users own contact if one exists. Otherwise returns null
 Future<String?> getOwnContactId() async {
   final prefs = await SharedPreferences.getInstance();
   return prefs.getString('own_contact_id');
 }
 
-
+/// Gets the contact object of the users own contact if one exists.
 Future<Contact?> getOwnContact() async {
   final contactId = await getOwnContactId();
   if (contactId != null) {

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,9 +6,11 @@ import FlutterMacOS
 import Foundation
 
 import file_selector_macos
+import shared_preferences_foundation
 import sqflite_darwin
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   flutter:
     sdk: flutter
   permission_handler: ^10.0.0
+  shared_preferences: ^2.2.0
 
 
   # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
I implemented a new view for the users own card.

First, the system checks whether the user has already marked a contact as their own contact, as the Flutter_contacts library does not offer the option of marking a contact as their own. If the user has already selected a contact, it is simply called up. 

If the user has not yet selected a contact, they can either select one from the list of existing contacts or create a new contact.

The last commit is just a small bugfix for the text fields in the contact cards. The part where the new contact is saved can be ignored, it will be replaced when the database connection is established.