### PR TITLE
feat/home_view_klickable

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -35,7 +35,8 @@ class _MyHomePageState extends State<MyHomePage> {
   int _selectedIndex = 0;
 
   static final List<Widget> _widgetOptions = <Widget>[
-    const LogContactsButton(),
+    //const LogContactsButton(),
+    const HomeContent(),
     const PersonCardView(), 
     const GraphScreen(),
   ];

--- a/lib/screens/dummy_person.dart
+++ b/lib/screens/dummy_person.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class DummyPersonView extends StatelessWidget {
+  final String name;
+
+  const DummyPersonView({Key? key, required this.name}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Kontakt Info'),
+      ),
+      body: Center(
+        child: Text(
+          'Diese Person heißt $name.',
+          style: TextStyle(fontSize: 18),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/home_view.dart
+++ b/lib/screens/home_view.dart
@@ -3,6 +3,7 @@ import 'package:connect2/screens/person_card_view.dart';
 import 'package:connect2/services/contacts_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_contacts/flutter_contacts.dart';
+import 'dummy_person.dart';
 
 // HomeContent Widget: Die scrollbare Liste
 class HomeContent extends StatefulWidget {
@@ -80,15 +81,26 @@ class HomeContentState extends State<HomeContent> {
         tooltip: 'Increment',
         child: const Icon(Icons.add),
       ),
-      body: ListView.builder(
-        itemCount: names.length,
-        itemBuilder: (context, index) {
-          return ListTile(
-            leading: const Icon(Icons.person),
-            title: Text(names[index]),
-          );
-        },
-      ),
+      body: contacts.isEmpty
+          ? Center(child: CircularProgressIndicator())
+          : ListView.builder(
+              itemCount: contacts.length,
+              itemBuilder: (context, index) {
+                final contact = contacts[index];
+                return ListTile(
+                  title: Text(contact.displayName),
+                  onTap: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) =>
+                            DummyPersonView(name: contact.displayName),
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
     );
   }
 }


### PR DESCRIPTION
The items in the Homeview list are now clickable.
When an item is pressed, it can trigger a function or navigate to a new screen.
Currently, a placeholder file (dummy_file.dart) is provided for testing the on-press functionality.
This file is intended for testing purposes only and can be discarded afterward.