### PR TITLE
feat: Now click opens the person_card_view with right contactId

### DIFF
--- a/lib/screens/home_view.dart
+++ b/lib/screens/home_view.dart
@@ -176,7 +176,7 @@ class HomeContentState extends State<HomeContent> {
                       context,
                       MaterialPageRoute(
                         builder: (context) =>
-                            DummyPersonView(name: contact.displayName),
+                            PersonCardView(contactId: int.parse(contact.id)),
                       ),
                     );
                   },


### PR DESCRIPTION
I simply replaced the dummy view on click of the contact in the home view with the person_card_view and the according contactId. Right now the view only loads Dummy Data but this will replaced with the correct api calls to load the contact data.

This should be a quickie, as you both like it most ;) @N3moAhead @jaleneu 